### PR TITLE
Implement basic move to location

### DIFF
--- a/game/src/cp_factory.rs
+++ b/game/src/cp_factory.rs
@@ -16,7 +16,8 @@ use bytes::BytesMut;
 use l2_core::shared_packets::common::ReadablePacket;
 use macro_common::PacketEnum;
 use strum::Display;
-use tracing::error;
+use tracing::{error, info};
+use crate::packets::from_client::move_to_location::MoveToLocation;
 
 #[derive(Clone, Debug, Display, PacketEnum)]
 pub enum PlayerPackets {
@@ -36,6 +37,8 @@ pub enum PlayerPackets {
     RequestManorList(RequestManorList),
     RequestKeyMapping(RequestKeyMapping),
     NoOp(NoOp),
+    MoveToLocation(MoveToLocation),
+
 }
 
 pub fn build_client_packet(mut data: BytesMut) -> anyhow::Result<PlayerPackets> {
@@ -43,6 +46,8 @@ pub fn build_client_packet(mut data: BytesMut) -> anyhow::Result<PlayerPackets> 
         bail!("Not enough data to build packet: {data:?}");
     }
     let packet_id = data.split_to(1); // skip 1st byte, because it's packet id
+    info!("Player packet ID: 0x{:02X}", packet_id[0]);
+
     match packet_id[0] {
         ProtocolVersion::PACKET_ID => {
             Ok(PlayerPackets::ProtocolVersion(ProtocolVersion::read(data)?))
@@ -54,6 +59,8 @@ pub fn build_client_packet(mut data: BytesMut) -> anyhow::Result<PlayerPackets> 
         CreateCharRequest::PACKET_ID => Ok(PlayerPackets::CreateCharRequest(
             CreateCharRequest::read(data)?,
         )),
+        MoveToLocation::PACKET_ID => Ok(PlayerPackets::MoveToLocation(
+            MoveToLocation::read(data)?)),
         Logout::PACKET_ID => Ok(PlayerPackets::Logout(Logout::read(data)?)),
         DeleteChar::PACKET_ID => Ok(PlayerPackets::DeleteChar(DeleteChar::read(data)?)),
         RestoreChar::PACKET_ID => Ok(PlayerPackets::RestoreChar(RestoreChar::read(data)?)),

--- a/game/src/packets/from_client/mod.rs
+++ b/game/src/packets/from_client/mod.rs
@@ -9,3 +9,4 @@ pub mod delete_char;
 pub mod char_restore;
 pub mod char_select;
 pub mod enter_world;
+pub mod move_to_location;

--- a/game/src/packets/from_client/move_to_location.rs
+++ b/game/src/packets/from_client/move_to_location.rs
@@ -1,0 +1,63 @@
+use anyhow::bail;
+use bytes::BytesMut;
+use kameo::message::{Context, Message};
+use tracing::{info, instrument};
+use entities::entities::character;
+use l2_core::shared_packets::common::ReadablePacket;
+use l2_core::shared_packets::read::ReadablePacketBuffer;
+use crate::packets::from_client::char_restore::RestoreChar;
+use crate::packets::from_client::char_select::SelectChar;
+use crate::packets::to_client::{CharSelectionInfo, CreateCharOk};
+use crate::packets::to_client::{CharMoveToLocation};
+
+use crate::pl_client::PlayerClient;
+
+#[derive(Debug, Clone)]
+pub struct MoveToLocation {
+    pub x_to: i32,
+    pub y_to: i32,
+    pub z_to: i32,
+    pub x_from: i32,
+    pub y_from: i32,
+    pub z_from: i32,
+}
+
+impl ReadablePacket for MoveToLocation {
+    const PACKET_ID: u8 = 0x0F;
+    const EX_PACKET_ID: Option<u16> = None;
+    fn read(data: BytesMut) -> anyhow::Result<Self> {
+        let mut buffer = ReadablePacketBuffer::new(data);
+        let packet = Self {
+            x_to: buffer.read_i32()?,
+            y_to: buffer.read_i32()?,
+            z_to: buffer.read_i32()?,
+            x_from: buffer.read_i32()?,
+            y_from: buffer.read_i32()?,
+            z_from: buffer.read_i32()?,
+        };
+        Ok(packet)
+    }
+}
+
+impl Message<MoveToLocation> for PlayerClient {
+    type Reply = anyhow::Result<()>;
+    #[instrument(skip(self, _ctx))]
+    async fn handle(
+        &mut self,
+        msg: MoveToLocation,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> anyhow::Result<()> {
+
+        info!("Received MoveToLocation packet {:?}", msg);
+        //TODO check with geodata if the location is valid.
+        let selected_char = self.try_get_selected_char();
+        self.send_packet(CharMoveToLocation::new(
+            selected_char.unwrap(),
+            msg.x_to,
+            msg.y_to,
+            msg.z_to
+        )?).await;
+
+        Ok(())
+    }
+}

--- a/game/src/packets/to_client/char_move_to_location.rs
+++ b/game/src/packets/to_client/char_move_to_location.rs
@@ -1,0 +1,36 @@
+use l2_core::game_objects::player::Player;
+use l2_core::shared_packets::write::SendablePacketBuffer;
+use crate::packets::to_client::CharEtcStatusUpdate;
+use macro_common::SendablePacket;
+
+
+#[allow(unused)]
+#[derive(Clone, Debug, SendablePacket)]
+pub struct CharMoveToLocation {
+    pub buffer: SendablePacketBuffer
+}
+
+#[allow(unused)]
+impl CharMoveToLocation {
+    const PACKET_ID: u8 = 0x2F;
+    const EX_PACKET_ID: Option<u16> = None;
+    pub fn new(p: &Player, target_x: i32, target_y: i32, target_z: i32) -> anyhow::Result<Self> {
+        let mut inst = Self {
+            buffer: SendablePacketBuffer::new(),
+        };
+        inst.buffer.write(Self::PACKET_ID)?;
+        inst.buffer.write_i32(p.get_id())?; // 1-7 increase force, level
+
+        // Target position
+        inst.buffer.write_i32(target_x)?;
+        inst.buffer.write_i32(target_y)?;
+        inst.buffer.write_i32(target_z)?;
+
+        // Source position
+        inst.buffer.write_i32(p.get_x())?;
+        inst.buffer.write_i32(p.get_y())?;
+        inst.buffer.write_i32(p.get_z())?;
+
+        Ok(inst)
+    }
+}

--- a/game/src/packets/to_client/mod.rs
+++ b/game/src/packets/to_client/mod.rs
@@ -21,6 +21,7 @@ mod acquire_skill_list;
 mod move_to;
 mod abnormal_status_update;
 mod system_message;
+mod char_move_to_location;
 
 pub use protocol_response::*;
 pub use login_response::*;
@@ -44,3 +45,4 @@ pub use acquire_skill_list::*;
 pub use move_to::*;
 pub use abnormal_status_update::*;
 pub use system_message::*;
+pub use char_move_to_location::*;

--- a/l2-core/src/game_objects/player/_player.rs
+++ b/l2-core/src/game_objects/player/_player.rs
@@ -106,6 +106,11 @@ impl Player {
     }
 
     #[must_use]
+    pub fn get_id(&self) -> i32 {
+        self.char_model.id
+    }
+
+    #[must_use]
     pub fn get_freight_slots(&self) -> u32 {
         200 //todo: implement me
     }


### PR DESCRIPTION
Here is a PR that implement a very basic move to location implementation. It does not check geodata for location validity nor if the player request a very far away location ... but it allow player to move using the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now move your character to a selected location; movement requests from the client are processed.
  * The server sends movement updates that include both destination and origin coordinates for smoother, more accurate on-screen movement.
  * Player identity is exposed for movement routing, improving reliability of movement actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->