### PR TITLE
Cleanup+ fix randomly failing tests because of `reset_for_tests` caus…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,6 @@ dependencies = [
  "kameo",
  "l2-core",
  "macro-common",
- "ntest",
  "num-traits",
  "rand",
  "sea-orm",
@@ -1590,6 +1589,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sqlx",
  "strum 0.27.2",
  "strum_macros",
@@ -1679,7 +1679,6 @@ dependencies = [
  "kameo",
  "l2-core",
  "macro-common",
- "ntest",
  "num",
  "pnet",
  "rand",
@@ -1751,39 +1750,6 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
-
-[[package]]
-name = "ntest"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb183f0a1da7a937f672e5ee7b7edb727bf52b8a52d531374ba8ebb9345c0330"
-dependencies = [
- "ntest_test_cases",
- "ntest_timeout",
-]
-
-[[package]]
-name = "ntest_test_cases"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d0d3f2a488592e5368ebbe996e7f1d44aa13156efad201f5b4d84e150eaa93"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ntest_timeout"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc7c92f190c97f79b4a332f5e81dcf68c8420af2045c936c9be0bc9de6f63b5"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2571,10 +2537,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
@@ -2799,6 +2780,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ uuid = { version = "^1.17.0", features = ["v4"] }
 strum = { version = "0.27.2", features = ["derive"] }
 async-std = { version = "1.13.1", features = ["attributes", "tokio1"] }
 bytes = "1.10.1"
-ntest = "0.9.3"
+serial_test = "3.2.0"

--- a/game/Cargo.toml
+++ b/game/Cargo.toml
@@ -26,9 +26,7 @@ kameo.workspace = true
 bytes.workspace = true
 dotenvy.workspace = true
 [dev-dependencies]
-ntest.workspace = true
 test-utils = { path = "../test-utils" }
 entities = { path = "../entities", features = ["test-factories"] }
-
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/game/src/packets/handleable/gs_auth_response.rs
+++ b/game/src/packets/handleable/gs_auth_response.rs
@@ -45,7 +45,6 @@ mod tests {
     use crate::test_utils::test::spawn_ls_client_actor;
     use l2_core::config::gs::GSServerConfig;
     use l2_core::traits::ServerConfig;
-    use ntest::timeout;
     use std::sync::Arc;
     use test_utils::utils::get_test_db;
     use tokio::io::{split, AsyncReadExt};

--- a/game/src/packets/handleable/init_ls.rs
+++ b/game/src/packets/handleable/init_ls.rs
@@ -38,7 +38,6 @@ mod tests {
     use l2_core::config::gs::GSServerConfig;
     use l2_core::crypt::rsa::ScrambledRSAKeyPair;
     use l2_core::traits::ServerConfig;
-    use ntest::timeout;
     use std::sync::Arc;
     use test_utils::utils::get_test_db;
     use tokio::io::{split, AsyncReadExt};

--- a/l2-core/Cargo.toml
+++ b/l2-core/Cargo.toml
@@ -43,3 +43,4 @@ kameo.workspace = true
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
+serial_test.workspace = true

--- a/l2-core/src/id_factory.rs
+++ b/l2-core/src/id_factory.rs
@@ -106,6 +106,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_allocation() {
         let factory = IdFactory::instance();
         factory.reset_for_tests();
@@ -116,6 +117,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_reuse() {
         let factory = IdFactory::instance();
         factory.reset_for_tests();

--- a/login/Cargo.toml
+++ b/login/Cargo.toml
@@ -22,7 +22,6 @@ pnet.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 sea-orm.workspace = true
-ntest.workspace = true
 kameo.workspace = true
 dotenvy.workspace = true
 bytes.workspace = true


### PR DESCRIPTION
…e it resets all the state for other tests in parallel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client status handling during restart operations.
  * Added validation guards for movement operations to prevent invalid state transitions.
  * Enhanced error messaging for movement failures.

* **Tests**
  * Updated test infrastructure to ensure proper test execution isolation.

* **Chores**
  * Updated testing dependencies for better compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->